### PR TITLE
Avoid KeyError

### DIFF
--- a/engine/csv_output.py
+++ b/engine/csv_output.py
@@ -117,7 +117,7 @@ class CsvOut:
                 # first check if there are any follow questions
                 if "followup_questions" not in self.instructions[workflow_id][task_id]["tools"][tool_id]:
                     continue
-                    
+
                 followup_questions = self.instructions[workflow_id][task_id]["tools"][tool_id]["followup_questions"]
 
                 # go through each of the follow up questions
@@ -859,7 +859,7 @@ class CsvOut:
         # on average, how many species did people see?
         # note - nothing here (or empty or what ever) counts as a species - we just won't give any follow up
         # answer responses
-        species_in_subject = aggregations["num species in image"]
+        species_in_subject = aggregations.get("num species in image", [])
 
         views_of_subject = aggregations["num users"]
 


### PR DESCRIPTION
Closes #158

I think this will just output an empty file rather than crashing. I'm
not sure why the "num species in image" key doesn't exist though...
