### PR TITLE
Increase queue job timeout

### DIFF
--- a/engine/web_api.py
+++ b/engine/web_api.py
@@ -11,7 +11,7 @@ import logging
 app = Flask(__name__)
 env = os.getenv('FLASK_ENV', 'production')
 #30 mins - http://python-rq.org/docs/results/
-q = Queue('default', connection=configure_redis(env), default_timeout=7200)
+q = Queue('default', connection=configure_redis(env), default_timeout=14400)
 apis = {
     'development': "http://"+str(os.getenv('HOST_IP', '172.17.42.1'))+":3000",
     'staging': "https://panoptes-staging.zooniverse.org",


### PR DESCRIPTION
This is the dumbest thing that could possibly work. It won't possibly work forever, but might solve the Camera CATalogue issue of not getting any aggregation results right now.