### PR TITLE
Send text aggregation summary email to owner/collaborators

### DIFF
--- a/engine/aggregation_api.py
+++ b/engine/aggregation_api.py
@@ -1351,7 +1351,8 @@ class AggregationAPI:
             Panoptes.connect(
                 endpoint=self.host,
                 username=self.user_name,
-                password=self.password
+                password=self.password,
+                admin=True
             )
 
         self.token = None

--- a/engine/text_aggregation.py
+++ b/engine/text_aggregation.py
@@ -19,7 +19,7 @@ from classification import Classification
 from helper_functions import warning
 from rectangle_clustering import RectangleClustering
 from transcription_output import ShakespearesWorldOutput,AnnotateOutput
-from panoptes_client import Workflow
+from panoptes_client import Project, Workflow
 from panoptes_client.panoptes import PanoptesAPIException
 
 __author__ = 'ggdhines'
@@ -180,7 +180,6 @@ class TranscriptionAPI(AggregationAPI):
         if "tags" in param_details[self.project_id]:
             additional_text_args["tags"] = param_details[self.project_id]["tags"]
 
-        self.email_recipients = param_details[self.project_id]["email"]
         self.project_name = param_details[self.project_id]["project_name"]
 
         # now that we have the additional text arguments, convert text_algorithm from a class
@@ -374,8 +373,14 @@ class TranscriptionAPI(AggregationAPI):
             Source='no-reply@zooniverse.org',
             Destination={
                 'ToAddresses': [
-                    'sysadmins@zooniverse.org',
-                    self.email_recipients
+                    u.email for u in Project.find(
+                        self.project_id
+                    ).collaborators(
+                        'owner',
+                        'collaborator',
+                        'researcher',
+                        'expert'
+                    )
                 ]
             },
             Message={

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,4 +16,4 @@ rq
 scikit-learn
 setproctitle
 termcolor
-panoptes-client>=0.4
+panoptes-client>=0.6


### PR DESCRIPTION
Rather than to the JISC lists.

Todo before this can be merged:

- [x] Release panoptes-client 0.6
- [x] Check with @vvh which groups should receive the emails

@vvh I've set it to send the emails to the owner and everyone who's marked as a "collaborator" on the collaborators page. Do we want it to also go to experts and/or researchers?